### PR TITLE
Added function to handle legacy instantiation

### DIFF
--- a/lib/nodio.js
+++ b/lib/nodio.js
@@ -3,12 +3,12 @@ var moment = require('moment');
 var _ = require('lodash');
 
 // Instantiate with a credentials object that is persistant
-function Nodio(credentials) {
+function Nodio (credentials) {
 
 	/**
 	 * The nodio object to be returned from the module
 	 *
-	 * @type	object
+	 * @type    object
 	 */
 	var nodio = {
 		VERSION: '0.0.2'
@@ -30,21 +30,21 @@ function Nodio(credentials) {
 	/**
 	 * Token that Podio returns to allow the interacting with an app
 	 *
-	 * @type	object
+	 * @type    object
 	 */
 	var access_token;
 
 	/**
 	 * Number of milliseconds in which the access token expires
 	 *
-	 * @type	integer
+	 * @type    integer
 	 */
 	var expires_in;
 
 	/**
 	 * The time the the access token was authenticated
 	 *
-	 * @type	object
+	 * @type    object
 	 */
 	var authentication_time;
 
@@ -52,9 +52,9 @@ function Nodio(credentials) {
 	/**
 	 * Validates the provided credentials against Podio's OAUTH api
 	 *
-	 * @param	function	callback		Run on completion
+	 * @param   function    callback        Run on completion
 	 *
-	 * @return	void
+	 * @return  void
 	 */
 	function validateCredentials (callback) {
 		//We're using the app authentication flow
@@ -88,10 +88,10 @@ function Nodio(credentials) {
 	/**
 	 * Add an item to the Podio app
 	 *
-	 * @param	type		item_fields		Must contain valid fields for the item
-	 * @param	function	callback		Function to run on completion
+	 * @param   type        item_fields     Must contain valid fields for the item
+	 * @param   function    callback        Function to run on completion
 	 *
-	 * return	void
+	 * return   void
 	 */
 	nodio.addNewItem = function(item_fields, callback) {
 
@@ -127,10 +127,10 @@ function Nodio(credentials) {
 	/**
 	 * Get an item based on its item ID
 	 *
-	 * @param	integer		item_id		ID of item to retrieve (must be within the specified Podio app)
-	 * @param	function	callback	Run on completion
+	 * @param   integer     item_id     ID of item to retrieve (must be within the specified Podio app)
+	 * @param   function    callback    Run on completion
 	 *
-	 * @return	void
+	 * @return  void
 	 */
 	nodio.getItem = function (item_id, callback) {
 		validateCredentials(function (err) {
@@ -158,6 +158,18 @@ function Nodio(credentials) {
 
 	return nodio;
 }
+
+
+/**
+ * Handle Nodio being instantiated in the old way.
+ *
+ */
+Nodio.addNewItem = function () {
+	console.log('Nodio must be instantiated with credentials in the form: require("nodio")(credentials);');
+};
+Nodio.getItem = function () {
+	console.log('Nodio must be instantiated with credentials in the form: require("nodio")(credentials);');
+};
 
 // Finally, export `Nodio` to the world.
 module.exports = Nodio;


### PR DESCRIPTION
Forgot to add functions so that people using nodio in the old way of

``` javascript
var nodio = require('nodio');
var credentials = {...};
var item = {...};

nodio.addItem(credentials, item, function () { });
```

would not cause node to fall over but instead will output a warning to console.
